### PR TITLE
Add unified top level usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,19 +70,8 @@ Instead, event listeners should only be used to update the local state (e.g. a l
 
 If you need to perform actions, for example setting up a first blog post after a new user has been created add it to the service method itself (which will only run on its own instance) or use [feather-hooks](https://github.com/feathersjs/feathers-hooks) after hooks.
 
-## Changelog
-
-__0.1.0__
-
-- Can now use Redis or Mongo
-- Initial release
-
-## Author
-
-- [David Luecke](https://github.com/daffl)
-
 ## License
 
-Copyright (c) 2015 David Luecke
+Copyright (c) 2018 Feathers contributors
 
 Licensed under the [MIT license](LICENSE).

--- a/lib/adapters/amqp.js
+++ b/lib/adapters/amqp.js
@@ -1,6 +1,6 @@
 const amqplib = require('amqplib');
 const debug = require('debug')('feathers-sync:amqp');
-const core = require('./core');
+const core = require('../core');
 
 module.exports = config => {
   const open = amqplib.connect(config.uri, config.amqpConnectionOptions);
@@ -34,6 +34,9 @@ module.exports = config => {
         });
       }).then(channel => ({ connection, channel })));
 
-    app.sync = { ready };
+    app.sync = {
+      ready,
+      type: 'amqp'
+    };
   };
 };

--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -1,11 +1,12 @@
 const mubsub = require('mubsub');
 const debug = require('debug')('feathers-sync:mongodb');
-const core = require('./core');
+const core = require('../core');
 
 module.exports = config => {
   const collection = config.collection || 'sync';
   const eventName = config.event || 'feathers-sync';
-  const client = mubsub(config.db, config.mubsub);
+  const db = config.uri || config.db;
+  const client = mubsub(db, config.mubsub);
   const channel = client.channel(collection, config.channel);
 
   debug(`Setting up MongoDB connection ${config.db} on collection ${collection}`);
@@ -15,6 +16,7 @@ module.exports = config => {
     app.sync = {
       client,
       channel,
+      type: 'mongodb',
       ready: new Promise((resolve, reject) => {
         channel.once('ready', resolve);
         channel.once('error', reject);

--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -1,19 +1,21 @@
 const redis = require('redis');
 const debug = require('debug')('feathers-sync:redis');
-const core = require('./core');
+const core = require('../core');
 
 module.exports = config => {
   return app => {
-    const pub = redis.createClient(config.db);
-    const sub = redis.createClient(config.db);
+    const db = config.uri || config.db;
+    const pub = redis.createClient(db);
+    const sub = redis.createClient(db);
     const key = config.key || 'feathers-sync';
 
-    debug(`Setting up Redis client for ${config.db}`);
+    debug(`Setting up Redis client for ${db}`);
 
     app.configure(core);
     app.sync = {
       pub,
       sub,
+      type: 'redis',
       ready: new Promise((resolve, reject) => {
         sub.once('ready', resolve);
         sub.once('error', reject);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,12 +1,32 @@
+const url = require('url');
 const core = require('./core');
-const mongodb = require('./mongodb');
-const redis = require('./redis');
-const amqp = require('./amqp');
-
-module.exports = {
+const mongodb = require('./adapters/mongodb');
+const redis = require('./adapters/redis');
+const amqp = require('./adapters/amqp');
+const mappings = {
   mongodb,
   core,
   redis,
   amqp,
   rabbitmq: amqp
 };
+
+module.exports = options => {
+  const { uri } = options;
+
+  if (!uri) {
+    throw new Error('A `uri` option with the database connection string has to be provided to feathers-sync');
+  }
+
+  const { protocol } = url.parse(uri);
+  const name = protocol.substring(0, protocol.length - 1);
+  const adapter = mappings[name];
+
+  if (!adapter) {
+    throw new Error(`${name} is an invalid adapter (uri ${uri})`);
+  }
+
+  return adapter(options);
+};
+
+Object.assign(module.exports, mappings);

--- a/test/adapters/amqp.test.js
+++ b/test/adapters/amqp.test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const _app = require('./app');
-const createApp = _app('amqp', {
+const createApp = _app({
   uri: 'amqp://guest:guest@localhost:5672'
 });
 
@@ -19,6 +19,11 @@ describe('feathers-sync AMQP tests', () => {
 
       return app3.sync.ready;
     });
+  });
+
+  it('initialized with amqp adapter', () => {
+    assert.ok(app1.sync);
+    assert.equal(app1.sync.type, 'amqp');
   });
 
   it('creating todo on app1 trigger created on all apps with hook context', done => {

--- a/test/adapters/app.js
+++ b/test/adapters/app.js
@@ -1,9 +1,9 @@
 const feathers = require('@feathersjs/feathers');
-const sync = require('../lib');
+const sync = require('../../lib');
 
-module.exports = (name, options) => {
+module.exports = options => {
   return () => feathers()
-    .configure(sync[name](options))
+    .configure(sync(options))
     .use('/todo', {
       events: ['custom'],
       create (data) {

--- a/test/adapters/mongodb.test.js
+++ b/test/adapters/mongodb.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const _app = require('./app');
-const createApp = _app('mongodb', {
-  db: 'mongodb://localhost:27017/feathers-sync'
+const createApp = _app({
+  uri: 'mongodb://localhost:27017/feathers-sync'
 });
 
 describe('feathers-sync MongoDB tests', () => {
@@ -19,6 +19,11 @@ describe('feathers-sync MongoDB tests', () => {
 
       return app3.sync.ready;
     });
+  });
+
+  it('initialized with mongodb adapter', () => {
+    assert.ok(app1.sync);
+    assert.equal(app1.sync.type, 'mongodb');
   });
 
   it('creating todo on app1 trigger created on all apps with hook context', done => {

--- a/test/adapters/redis.test.js
+++ b/test/adapters/redis.test.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const _app = require('./app');
-const createApp = _app('redis', {
-  db: 'redis://localhost:6379'
+const createApp = _app({
+  uri: 'redis://localhost:6379'
 });
 
 describe('feathers-sync Redis tests', () => {
@@ -19,6 +19,11 @@ describe('feathers-sync Redis tests', () => {
 
       return app3.sync.ready;
     });
+  });
+
+  it('initialized with redis adapter', () => {
+    assert.ok(app1.sync);
+    assert.equal(app1.sync.type, 'redis');
   });
 
   it('creating todo on app1 trigger created on all apps with hook context', done => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,26 @@
+const feathers = require('@feathersjs/feathers');
+const assert = require('assert');
+const sync = require('../lib');
+
+describe('feathers-sync tests', () => {
+  it('exports db adapters', () => {
+    assert.equal(typeof sync, 'function');
+    assert.ok(sync.mongodb);
+    assert.ok(sync.redis);
+    assert.ok(sync.amqp);
+  });
+
+  it('throws an error when uri is missing', () => {
+    assert.throws(() => {
+      feathers().configure(sync({}));
+    }, /A `uri` option with the database connection string has to be provided/);
+  });
+
+  it('throws an error for invalid adapter', () => {
+    assert.throws(() => {
+      feathers().configure(sync({
+        uri: 'something://localhost'
+      }));
+    }, /something is an invalid adapter/);
+  });
+});


### PR DESCRIPTION
This allows to use `feathers-sync` the same based on the adapters `uri` (related to #16).