### PR TITLE
Add function to sync a service dynamically after app launch

### DIFF
--- a/src/amqp.js
+++ b/src/amqp.js
@@ -123,11 +123,8 @@ module.exports = function (config) {
 
     if (this.version && parseInt(this.version, 10) >= 3) {
       this.mixins.push(configurePlugin);
-    }
-    else {
+    } else {
       this.providers.push((path, service) => configurePlugin(service, path));
     }
-
-
   };
 };

--- a/src/redis.js
+++ b/src/redis.js
@@ -32,7 +32,7 @@ module.exports = function (config) {
       return result;
     };
 
-    function configurePlugin(service, path) {
+    function configurePlugin (service, path) {
       if (typeof service.emit !== 'function' || typeof service.on !== 'function') {
         return;
       }
@@ -57,8 +57,7 @@ module.exports = function (config) {
 
     if (this.version && parseInt(this.version, 10) >= 3) {
       this.mixins.push(configurePlugin);
-    }
-    else {
+    } else {
       this.providers.push((path, service) => configurePlugin(service, path));
     }
   };


### PR DESCRIPTION
This PR allow to sync services that have been created after the app has been launched, i.e. after `app.listen()`.

We only applied the fix to our use case: MongoDB and Auk release. We created a branch starting from v0.1.4 since only a tags seem to exist on Auk compatible releases.

We believe it should be great to make it available as well on V3.