### PR TITLE
 Send safely stringified data to MongoDB

### DIFF
--- a/lib/adapters/mongodb.js
+++ b/lib/adapters/mongodb.js
@@ -25,12 +25,12 @@ module.exports = config => {
 
     app.on('sync-out', data => {
       debug(`Publishing ${eventName} event to mubsub channel`);
-      channel.publish(eventName, data);
+
+      channel.publish(eventName, JSON.stringify(data));
     });
 
     channel.subscribe(eventName, data => {
-      debug(`Got ${eventName} event from mubsub channel`);
-      app.emit('sync-in', data);
+      app.emit('sync-in', JSON.parse(data));
     });
   };
 };

--- a/test/adapters/app.js
+++ b/test/adapters/app.js
@@ -8,6 +8,9 @@ module.exports = options => {
       events: ['custom'],
       create (data) {
         return Promise.resolve(data);
+      },
+      update (id, data, params) {
+        return Promise.resolve(data);
       }
     });
 };

--- a/test/adapters/mongodb.test.js
+++ b/test/adapters/mongodb.test.js
@@ -54,4 +54,35 @@ describe('feathers-sync MongoDB tests', () => {
       assert.deepEqual(original, data)
     ).catch(done);
   });
+
+  it('updating todo on app1 with query operators trigger update on all apps with hook context', done => {
+    const original = { test: 'data' };
+    const query = { field: { $lt: 3 } };
+    let count = 0;
+    const onUpdated = app => {
+      app.service('todo').once('updated', (data, context) => {
+        assert.deepEqual(original, data);
+        assert.ok(context);
+        assert.deepEqual(context.result, data);
+        assert.equal(context.method, 'update');
+        assert.equal(context.type, 'after');
+        assert.equal(context.service, app.service('todo'));
+        assert.equal(context.app, app);
+        assert.deepEqual(context.params, { query });
+        
+        count++;
+        if (count === 3) {
+          done();
+        }
+      });
+    };
+
+    onUpdated(app1);
+    onUpdated(app2);
+    onUpdated(app3);
+
+    app1.service('todo').update(null, { test: 'data' }, { query }).then(data =>
+      assert.deepEqual(original, data)
+    ).catch(done);
+  });
 });

--- a/test/adapters/mongodb.test.js
+++ b/test/adapters/mongodb.test.js
@@ -69,7 +69,7 @@ describe('feathers-sync MongoDB tests', () => {
         assert.equal(context.service, app.service('todo'));
         assert.equal(context.app, app);
         assert.deepEqual(context.params, { query });
-        
+
         count++;
         if (count === 3) {
           done();


### PR DESCRIPTION
This was causing issues when the data contained `$` (and probably `.`) keys.

Closes #83, should also close #80 and already includes and closes #84 