### PR TITLE
add adapterType option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,21 +12,36 @@ const mappings = {
 };
 
 module.exports = options => {
-  const { uri } = options;
-
-  if (!uri) {
+  if (!options.uri) {
     throw new Error('A `uri` option with the database connection string has to be provided to feathers-sync');
   }
 
-  const { protocol } = url.parse(uri);
-  const name = protocol.substring(0, protocol.length - 1);
-  const adapter = mappings[name];
-
-  if (!adapter) {
-    throw new Error(`${name} is an invalid adapter (uri ${uri})`);
-  }
+  const adapter = getAdapter(options);
 
   return adapter(options);
 };
+
+function getAdapter (options) {
+  const { uri, adapterType } = options;
+  let adapter;
+
+  if (adapterType) {
+    adapter = mappings[adapterType];
+
+    if (!adapter) {
+      throw new Error(`${adapterType} is an invalid adapter (adapterType ${adapterType})`);
+    }
+  } else {
+    const { protocol } = url.parse(uri);
+    const name = protocol.substring(0, protocol.length - 1);
+    adapter = mappings[name];
+
+    if (!adapter) {
+      throw new Error(`${name} is an invalid adapter (uri ${uri})`);
+    }
+  }
+
+  return adapter;
+}
 
 Object.assign(module.exports, mappings);


### PR DESCRIPTION
### Summary

Hello
I encountered such a problem, when an adapter has a secure url, like: `amqps://user:pass` feathers-sync throw an exception:
`amqps is an invalid adapter (uri amqps)`
In this PR I added a `adapterType` with which you can choose the explicit adapter.