### PR TITLE
Allow to disable synchronization in a hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ app.sync.ready.then(() => {
 });
 ```
 
+### Disabling synchronization
+
+
+
 ## Adapters
 
 `feathers-sync` can be initialized either by specifying the type of adapter through the `uri` (e.g. `mongodb://localhost:27017/sync`) or using e.g. `sync.mongodb` directly:

--- a/README.md
+++ b/README.md
@@ -53,7 +53,24 @@ app.sync.ready.then(() => {
 
 ### Disabling synchronization
 
+`feathers-sync` can be disabled on the service method call level in a hook by setting the `require('feathers-sync').SYNC` property on the hook context to `false`:
 
+```js
+const { SYNC } = require('feathers-sync');
+
+app.service('messages').hooks({
+  after: {
+    create(context) {
+      // Don't synchronize if more than 1000 items were created at once
+      if(context.result.length > 1000) {
+        context[SYNC] = false;
+      }
+
+      return context;
+    }
+  }
+});
+```
 
 ## Adapters
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -1,13 +1,13 @@
 const debug = require('debug')('feathers-sync');
 const { hooks, _ } = require('@feathersjs/commons');
-const SYNC_ENABLED = Symbol('feathers-sync/enabled');
+const SYNC = Symbol('feathers-sync/enabled');
 
 module.exports = app => {
-  if (app[SYNC_ENABLED]) {
+  if (app[SYNC]) {
     return;
   }
 
-  app[SYNC_ENABLED] = true;
+  app[SYNC] = true;
 
   if (app.sync) {
     throw new Error('Only one type of feathers-sync can be configured on the same application');
@@ -31,7 +31,7 @@ module.exports = app => {
     service._emit = service.emit;
     service.mixin({
       emit (event, data, ctx) {
-        if (!service._serviceEvents.includes(event)) {
+        if (!service._serviceEvents.includes(event) || ctx[SYNC] === false) {
           debug(`Passing through non-service event '${path} ${event}'`);
           return this._emit(event, data, ctx);
         }
@@ -48,3 +48,5 @@ module.exports = app => {
     });
   });
 };
+
+module.exports.SYNC = SYNC;

--- a/lib/core.js
+++ b/lib/core.js
@@ -31,7 +31,9 @@ module.exports = app => {
     service._emit = service.emit;
     service.mixin({
       emit (event, data, ctx) {
-        if (!service._serviceEvents.includes(event) || ctx[SYNC] === false) {
+        const disabled = ctx && ctx[SYNC] === false;
+
+        if (!service._serviceEvents.includes(event) || disabled) {
           debug(`Passing through non-service event '${path} ${event}'`);
           return this._emit(event, data, ctx);
         }

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -46,15 +46,17 @@ describe('feathers-sync core tests', () => {
 
   it('can skip sending sync event', done => {
     const message = 'This is a test';
+    const handler = () => {
+      done(new Error('Should never get here'));
+    };
 
     app.service('todo').once('created', todo => {
       assert.equal(todo.message, message);
+      app.removeListener('sync-out', handler);
       done();
     });
 
-    app.once('sync-out', () => {
-      done(new Error('Should never get here'));
-    });
+    app.once('sync-out', handler);
 
     let synced = false;
 

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -1,10 +1,10 @@
 const assert = require('assert');
 const feathers = require('@feathersjs/feathers');
-const core = require('../lib/core');
+const sync = require('../lib/core');
 
 describe('feathers-sync core tests', () => {
   const app = feathers()
-    .configure(core)
+    .configure(sync)
     .use('/todo', {
       events: ['custom'],
       create (data) {
@@ -13,7 +13,7 @@ describe('feathers-sync core tests', () => {
     });
 
   it('configuring twice does nothing', () => {
-    app.configure(core);
+    app.configure(sync);
   });
 
   it('sends sync-out for service events', done => {
@@ -42,6 +42,33 @@ describe('feathers-sync core tests', () => {
     });
 
     app.service('todo').create(message);
+  });
+
+  it('can skip sending sync event', done => {
+    const message = 'This is a test';
+
+    app.service('todo').once('created', todo => {
+      assert.equal(todo.message, message);
+      done();
+    });
+
+    app.once('sync-out', () => {
+      done(new Error('Should never get here'));
+    });
+
+    let synced = false;
+
+    app.service('todo').hooks({
+      before (context) {
+        if (!synced) {
+          context[sync.SYNC] = false;
+          synced = true;
+        }
+
+        return context;
+      }
+    });
+    app.service('todo').create({ message });
   });
 
   it('sends sync-out for custom events', done => {


### PR DESCRIPTION
This pull requests allows to disable `feathers-sync` in a hook.

Closes #95