### PR TITLE
added support for passing in existing redis connection to the adapter, which also enables support for ioredis; the redis ready events now race so only one will resolve/reject

### DIFF
--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -3,36 +3,36 @@ const debug = require('debug')('feathers-sync:redis');
 const core = require('../core');
 
 module.exports = config => {
-  return app => {
-    const db = config.uri || config.db;
-    const pub = redis.createClient(db);
-    const sub = redis.createClient(db);
-    const key = config.key || 'feathers-sync';
+    return app => {
+        const key = config.key || 'feathers-sync';
+        const db = config.uri || config.db;
+        if (typeof db !== "undefined")
+            debug(`Setting up Redis client for ${db}`);
+        const pub = config.pub || redis.createClient(db);
+        const sub = config.sub || redis.createClient(db);
+    
+        app.configure(core);
+        app.sync = {
+            pub,
+            sub,
+            type: 'redis',
+            ready: Promise.race([
+                new Promise((resolve, reject) => sub.once('ready', resolve)),
+                new Promise((resolve, reject) => sub.once('error', reject))
+            ])
+        };
 
-    debug(`Setting up Redis client for ${db}`);
+        app.on('sync-out', data => {
+            debug(`Publishing key ${key} to Redis`);
+            pub.publish(key, JSON.stringify(data));
+        });
 
-    app.configure(core);
-    app.sync = {
-      pub,
-      sub,
-      type: 'redis',
-      ready: new Promise((resolve, reject) => {
-        sub.once('ready', resolve);
-        sub.once('error', reject);
-      })
+        sub.subscribe(key);
+        sub.on('message', function (e, data) {
+            if (e === key) {
+                debug(`Got ${key} message from Redis`);
+                app.emit('sync-in', JSON.parse(data));
+            }
+        });
     };
-
-    app.on('sync-out', data => {
-      debug(`Publishing key ${key} to Redis`);
-      pub.publish(key, JSON.stringify(data));
-    });
-
-    sub.subscribe(key);
-    sub.on('message', function (e, data) {
-      if (e === key) {
-        debug(`Got ${key} message from Redis`);
-        app.emit('sync-in', JSON.parse(data));
-      }
-    });
-  };
 };


### PR DESCRIPTION
This adds support for passing in existing redis connection(s) to the adapter, consequently allowing support for ioredis and other clients. The redis ready events also now race so only one will resolve/reject, whereas before the error promise would reject on the first error, even after the adapter indicated it was ready. Sorry about the ugly diff.