### PR TITLE
Duplicate redisClient (bug fix) * Customize subscriber event 

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ app.configure(sync.redis({
 
 // Configure Redis using an existing redisClient
 app.configure(sync.redis({
-  redisClient: redisClient 
+  redisClient: redisClient
 }))
 ```
 
@@ -99,6 +99,7 @@ app.configure(sync.redis({
 - `key` - The key under which all synchronization events will be stored (default: `feathers-sync`)
 - `redisClient` - An existing instance of redisClient
 - `redisOptions` - Redis [client options](http://redis.js.org/#api-rediscreateclient)
+- `subscriberEvent` - The event to listen for. Defaults to `message`. Could be `message_buffer` or `messageBuffer` depending on what Redis library is being used.
 
 ### AMQP
 
@@ -112,7 +113,7 @@ app.configure(sync.redis({
 
 ## Caveat: Listening to service events
 
-With `feathers-sync` enabled all events are going to get propagated to every application instance. This means, that any event listeners registered _on the server_ should not perform any actions that change the global state (e.g. write something into the database or call to an external API) because it will end up running multiple times (once on each instance). Instead, event listeners should only be used to update the local state (e.g. a local cache) and send real-time updates to all its clients. 
+With `feathers-sync` enabled all events are going to get propagated to every application instance. This means, that any event listeners registered _on the server_ should not perform any actions that change the global state (e.g. write something into the database or call to an external API) because it will end up running multiple times (once on each instance). Instead, event listeners should only be used to update the local state (e.g. a local cache) and send real-time updates to all its clients.
 
 If you need to perform actions, for example setting up a first blog post after a new user has been created, add it to the service method itself or use a [Feathers hook](https://docs.feathersjs.com/api/hooks.html) (both of which will only run once on the instance that is handling the request).
 

--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -8,7 +8,7 @@ module.exports = config => {
     const db = config.uri || config.db;
     const { redisClient } = config;
     // NOTE: message_buffer (redis) and messageBuffer (ioredis) return buffers
-    const subscriberEvent = config.subscriberEvent || 'message'
+    const subscriberEvent = config.subscriberEvent || 'message';
 
     if (!redisClient && typeof db !== 'undefined') {
       debug(`Setting up Redis client for db: ${db}`);

--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -11,6 +11,7 @@ module.exports = config => {
     if (!redisClient && typeof db !== "undefined")
       debug(`Setting up Redis client for db: ${db}`);
 
+    // NOTE: duplicate() works with redis and ioredis
     const [pub, sub] = redisClient ? [redisClient, redisClient.duplicate()] : [
       redis.createClient(db, config.redisOptions),
       redis.createClient(db, config.redisOptions)

--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -11,8 +11,16 @@ module.exports = config => {
     if (!redisClient && typeof db !== "undefined")
       debug(`Setting up Redis client for db: ${db}`);
 
-    const pub = redisClient || redis.createClient(db, config.redisOptions);
-    const sub = redisClient || redis.createClient(db, config.redisOptions);
+    let pub
+    let sub
+
+    if (redisClient) {
+      pub = redisClient;
+      sub = redisClient.duplicate();
+    } else {
+      pub = redis.createClient(db, config.redisOptions);
+      sub = redis.createClient(db, config.redisOptions);
+    }
 
     const { deserialize, serialize } = config;
 

--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -11,16 +11,10 @@ module.exports = config => {
     if (!redisClient && typeof db !== "undefined")
       debug(`Setting up Redis client for db: ${db}`);
 
-    let pub
-    let sub
-
-    if (redisClient) {
-      pub = redisClient;
-      sub = redisClient.duplicate();
-    } else {
-      pub = redis.createClient(db, config.redisOptions);
-      sub = redis.createClient(db, config.redisOptions);
-    }
+    const [pub, sub] = redisClient ? [redisClient, redisClient.duplicate()] : [
+      redis.createClient(db, config.redisOptions),
+      redis.createClient(db, config.redisOptions)
+    ];
 
     const { deserialize, serialize } = config;
 

--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -7,9 +7,12 @@ module.exports = config => {
     const key = config.key || 'feathers-sync';
     const db = config.uri || config.db;
     const { redisClient } = config;
+    // NOTE: message_buffer (redis) and messageBuffer (ioredis) return buffers
+    const subscriberEvent = config.subscriberEvent || 'message'
 
-    if (!redisClient && typeof db !== "undefined")
+    if (!redisClient && typeof db !== 'undefined') {
       debug(`Setting up Redis client for db: ${db}`);
+    }
 
     // NOTE: duplicate() works with redis and ioredis
     const [pub, sub] = redisClient ? [redisClient, redisClient.duplicate()] : [
@@ -38,7 +41,7 @@ module.exports = config => {
     });
 
     sub.subscribe(key);
-    sub.on('message', function (e, data) {
+    sub.on(subscriberEvent, function (e, data) {
       if (e.toString() === key) {
         debug(`Got ${key} message from Redis`);
         app.emit('sync-in', data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "feathers-sync",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "feathers-sync",
   "description": "Feathers",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/feathersjs-ecosystem/feathers-sync.git"


### PR DESCRIPTION
* Allow for the customization of the subscriber event to use message buffers with `ioredis`. Could also be useful for the `redis` package.
* Duplicate `redisClient` since we need two connections, one for `publish` and one for `subscribe`.