### PR TITLE
[#143] amqp retry mechanism

### DIFF
--- a/lib/adapters/amqp.js
+++ b/lib/adapters/amqp.js
@@ -1,44 +1,77 @@
-const amqplib = require('amqplib');
-const debug = require('debug')('feathers-sync:amqp');
-const core = require('../core');
+const amqpConnectionManager = require("amqp-connection-manager");
+const debug = require("debug")("feathers-sync:amqp");
+const core = require("../core");
 
-module.exports = config => {
-  const open = amqplib.connect(config.uri, config.amqpConnectionOptions);
-  const { deserialize, serialize, key } = config;
-
+module.exports = (config) => {
+  const amqpConnection = amqpConnectionManager.connect(
+    [config.uri],
+    config.amqpConnectionOptions
+  );
+  const { deserialize, serialize, key = "feathersSync" } = config;
   debug(`Setting up AMQP connection ${config.uri}`);
-
-  return app => {
+  return (app) => {
     app.configure(core);
+    const channelWrapper = amqpConnection.createChannel({
+      json: true,
+      setup: async (channel) => {
+        try {
+          // Creates a broadcast channel
+          await channel.assertExchange(key, "fanout", { durable: false });
 
-    const ready = open.then(connection => connection.createChannel()
-      .then(channel => {
-        return channel.assertExchange(key, 'fanout', { durable: false }).then(() => {
-          return channel.assertQueue('', { autoDelete: true }).then(q => {
-            channel.bindQueue(q.queue, key, '').then(() => {
-              channel.consume(q.queue, message => {
-                if (message !== null) {
-                  debug(`Got ${key} event from APMQ channel`);
-                  app.emit('sync-in', message.content);
-                }
-              }, { noAck: true });
-
-              app.on('sync-out', data => {
-                debug(`Publishing ${key} event to APMQ channel`);
-                channel.publish(key, '', Buffer.from(data));
-              });
-
-              return channel;
-            });
+          // Creates a queue and the data will be deleted after delivering being consumed.
+          const { queue } = await channel.assertQueue("", {
+            autoDelete: true,
           });
-        });
-      }).then(channel => ({ connection, channel })));
+          // Binds the exchange broadcast to the queue
+          await channel.bindQueue(queue, key, "queue-binding");
 
+          // Send the message to the service
+          channel.consume(
+            queue,
+            (message) => {
+              if (message !== null) {
+                debug(`Got ${key} event from APMQ channel`);
+                app.emit("sync-in", message.content);
+              }
+            },
+            { noAck: true }
+          );
+          // Publish the received message to the queue
+          app.on("sync-out", (data) => {
+            try {
+              const publishResponse = channel.publish(
+                key,
+                queue,
+                Buffer.from(data)
+              );
+              debug(`Publish success: |${publishResponse}| APMQ channel`);
+            } catch (error) {
+              debug(`Publish fail: |${error.message}| APMQ channel`);
+            }
+          });
+          return channel;
+        } catch (error) {
+          debug(`Publish fail: |${error.message}| APMQ channel`);
+        }
+      },
+    });
+    const ready = new Promise((resolve, reject) => {
+      channelWrapper.on("close", () => {
+        reject(new Error("Channel was closed unexpectedly"));
+      });
+      channelWrapper.on("connect", () => {
+        resolve();
+      });
+      channelWrapper.on("error", (error) => {
+        reject(new Error(error.message));
+      });
+    });
     app.sync = {
       deserialize,
       serialize,
       ready,
-      type: 'amqp'
+      connection: amqpConnection, // can be useful for tracking amqp connection states
+      type: "amqp",
     };
   };
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -740,6 +740,14 @@
         "uri-js": "^4.2.2"
       }
     },
+    "amqp-connection-manager": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/amqp-connection-manager/-/amqp-connection-manager-3.2.1.tgz",
+      "integrity": "sha512-dDs2hg8MEtuYlXMzIqWwFx4N5Fjm8vXAQNyukDavyrYsgnQVt+rtJ+oosMP7eOXukSdquCoVqOaWr/Ih6txwTA==",
+      "requires": {
+        "promise-breaker": "^5.0.0"
+      }
+    },
     "amqplib": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.6.0.tgz",
@@ -8934,6 +8942,11 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise-breaker": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/promise-breaker/-/promise-breaker-5.0.0.tgz",
+      "integrity": "sha512-mgsWQuG4kJ1dtO6e/QlNDLFtMkMzzecsC69aI5hlLEjGHFNpHrvGhFi4LiK5jg2SMQj74/diH+wZliL9LpGsyA=="
     },
     "prop-types": {
       "version": "15.7.2",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "src": "src"
   },
   "dependencies": {
+    "amqp-connection-manager": "^3.2.1",
     "amqplib": "^0.6.0",
     "debug": "^4.3.1",
     "lodash": "^4.17.20",


### PR DESCRIPTION
This PR addresses the issue [#143](https://github.com/feathersjs-ecosystem/feathers-sync/issues/143) the implementation is only relevant for amqp adapter, which properly reconnects after RabbitMQ goes down. 