### PR TITLE
chore: Migrate to async/await and require Node 12 or later

### DIFF
--- a/lib/adapters/amqp.js
+++ b/lib/adapters/amqp.js
@@ -1,13 +1,13 @@
-const amqpConnectionManager = require("amqp-connection-manager");
-const debug = require("debug")("feathers-sync:amqp");
-const core = require("../core");
+const amqpConnectionManager = require('amqp-connection-manager');
+const debug = require('debug')('feathers-sync:amqp');
+const core = require('../core');
 
 module.exports = (config) => {
   const amqpConnection = amqpConnectionManager.connect(
     [config.uri],
     config.amqpConnectionOptions
   );
-  const { deserialize, serialize, key = "feathersSync" } = config;
+  const { deserialize, serialize, key = 'feathersSync' } = config;
   debug(`Setting up AMQP connection ${config.uri}`);
   return (app) => {
     app.configure(core);
@@ -16,14 +16,14 @@ module.exports = (config) => {
       setup: async (channel) => {
         try {
           // Creates a broadcast channel
-          await channel.assertExchange(key, "fanout", { durable: false });
+          await channel.assertExchange(key, 'fanout', { durable: false });
 
           // Creates a queue and the data will be deleted after delivering being consumed.
-          const { queue } = await channel.assertQueue("", {
-            autoDelete: true,
+          const { queue } = await channel.assertQueue('', {
+            autoDelete: true
           });
           // Binds the exchange broadcast to the queue
-          await channel.bindQueue(queue, key, "queue-binding");
+          await channel.bindQueue(queue, key, 'queue-binding');
 
           // Send the message to the service
           channel.consume(
@@ -31,13 +31,13 @@ module.exports = (config) => {
             (message) => {
               if (message !== null) {
                 debug(`Got ${key} event from APMQ channel`);
-                app.emit("sync-in", message.content);
+                app.emit('sync-in', message.content);
               }
             },
             { noAck: true }
           );
           // Publish the received message to the queue
-          app.on("sync-out", (data) => {
+          app.on('sync-out', (data) => {
             try {
               const publishResponse = channel.publish(
                 key,
@@ -53,16 +53,16 @@ module.exports = (config) => {
         } catch (error) {
           debug(`Publish fail: |${error.message}| APMQ channel`);
         }
-      },
+      }
     });
     const ready = new Promise((resolve, reject) => {
-      channelWrapper.on("close", () => {
-        reject(new Error("Channel was closed unexpectedly"));
+      channelWrapper.on('close', () => {
+        reject(new Error('Channel was closed unexpectedly'));
       });
-      channelWrapper.on("connect", () => {
+      channelWrapper.on('connect', () => {
         resolve();
       });
-      channelWrapper.on("error", (error) => {
+      channelWrapper.on('error', (error) => {
         reject(new Error(error.message));
       });
     });
@@ -71,7 +71,7 @@ module.exports = (config) => {
       serialize,
       ready,
       connection: amqpConnection, // can be useful for tracking amqp connection states
-      type: "amqp",
+      type: 'amqp'
     };
   };
 };

--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -15,7 +15,7 @@ module.exports = config => {
     }
     
     const pub = redisClient || redis.createClient(db, config.redisOptions);
-    const sub = redisClient.duplicate();
+    const sub = pub.duplicate();
 
     app.configure(core);
     app.sync = {

--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -14,12 +14,8 @@ module.exports = config => {
       debug(`Setting up Redis client for db: ${db}`);
     }
     
-    const [pub, sub] = redisClient
-      ? [redisClient, redisClient.duplicate()]
-      : [
-        redis.createClient(db, config.redisOptions),
-        redis.createClient(db, config.redisOptions)
-      ];
+    const pub = redisClient || redis.createClient(db, config.redisOptions);
+    const sub = redisClient.duplicate();
 
     app.configure(core);
     app.sync = {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "Feathers contributors (https://feathersjs.com)",
   "contributors": [],
   "engines": {
-    "node": ">= 6"
+    "node": ">= 12"
   },
   "main": "lib/",
   "scripts": {

--- a/test/adapters/amqp.test.js
+++ b/test/adapters/amqp.test.js
@@ -11,18 +11,15 @@ describe('feathers-sync AMQP tests', () => {
 
   let app1, app2, app3;
 
-  before(() => {
+  before(async () => {
     app1 = createApp();
+    await app1.sync.ready;
+    
+    app2 = createApp();
+    await app2.sync.ready;
 
-    return app1.sync.ready.then(() => {
-      app2 = createApp();
-
-      return app2.sync.ready;
-    }).then(() => {
-      app3 = createApp();
-
-      return app3.sync.ready;
-    });
+    app3 = createApp();
+    await app3.sync.ready;
   });
 
   it('initialized with amqp adapter', () => {

--- a/test/adapters/app.js
+++ b/test/adapters/app.js
@@ -6,11 +6,11 @@ module.exports = options => {
     .configure(sync(options))
     .use('/todo', {
       events: ['custom'],
-      create (data) {
-        return Promise.resolve(data);
+      async create (data) {
+        return data;
       },
-      update (id, data, params) {
-        return Promise.resolve(data);
+      async update (id, data, params) {
+        return data;
       }
     });
 };

--- a/test/adapters/nats.test.js
+++ b/test/adapters/nats.test.js
@@ -8,15 +8,16 @@ describe('feathers-sync NATS tests', () => {
   });
 
   let app1, app2, app3;
-  before(() => {
+
+  before(async () => {
     app1 = createApp();
-    return app1.sync.ready.then(() => {
-      app2 = createApp();
-      return app2.sync.ready;
-    }).then(() => {
-      app3 = createApp();
-      return app3.sync.ready;
-    });
+    await app1.sync.ready;
+    
+    app2 = createApp();
+    await app2.sync.ready;
+
+    app3 = createApp();
+    await app3.sync.ready;
   });
 
   it('initialized with NATS adapter', () => {

--- a/test/adapters/redis.test.js
+++ b/test/adapters/redis.test.js
@@ -9,18 +9,15 @@ describe('feathers-sync Redis tests', () => {
 
   let app1, app2, app3;
 
-  before(() => {
+  before(async () => {
     app1 = createApp();
+    await app1.sync.ready;
 
-    return app1.sync.ready.then(() => {
-      app2 = createApp();
+    app2 = createApp();
+    await app2.sync.ready;
 
-      return app2.sync.ready;
-    }).then(() => {
-      app3 = createApp();
-
-      return app3.sync.ready;
-    });
+    app3 = createApp();
+    await app3.sync.ready;
   });
 
   it('initialized with redis adapter', () => {
@@ -69,18 +66,15 @@ describe('feathers-sync Redis custom serializer / deserializer tests', () => {
 
   let app1, app2, app3;
 
-  before(() => {
+  before(async () => {
     app1 = createApp();
+    await app1.sync.ready;
 
-    return app1.sync.ready.then(() => {
-      app2 = createApp();
+    app2 = createApp();
+    await app2.sync.ready;
 
-      return app2.sync.ready;
-    }).then(() => {
-      app3 = createApp();
-
-      return app3.sync.ready;
-    });
+    app3 = createApp();
+    await app3.sync.ready;
   });
 
   it('should sync data with binary serializer', done => {

--- a/test/core.test.js
+++ b/test/core.test.js
@@ -7,8 +7,8 @@ describe('feathers-sync core tests', () => {
     .configure(sync)
     .use('/todo', {
       events: ['custom'],
-      create (data) {
-        return Promise.resolve(data);
+      async create (data) {
+        return data;
       }
     });
 


### PR DESCRIPTION
Follow-up to #160 which already uses `async/await`