### PR TITLE
Subscribe to Redis messages after Redis client connects. Subscribing …

### DIFF
--- a/lib/adapters/redis.js
+++ b/lib/adapters/redis.js
@@ -17,6 +17,11 @@ module.exports = config => {
     const pub = redisClient || redis.createClient(options);
     const sub = pub.duplicate();
 
+    const msgFromRedisHandler = (key, data => {
+      debug(`Got ${key} message from Redis`);
+      app.emit('sync-in', data);
+    }, true);
+
     app.configure(core);
     app.sync = {
       deserialize,
@@ -29,17 +34,12 @@ module.exports = config => {
         sub.connect();
         sub.once('ready', resolve);
         sub.once('error', reject);
-      })
+      }).then(() => sub.subscribe(msgFromRedisHandler))
     };
 
     app.on('sync-out', data => {
       debug(`Publishing key ${key} to Redis`);
       pub.publish(key, data);
     });
-
-    sub.subscribe(key, data => {
-      debug(`Got ${key} message from Redis`);
-      app.emit('sync-in', data);
-    }, true);
   };
 };


### PR DESCRIPTION
…before connection causes _RedisCommandsQueue_pubSubState in node-redis 4.x to get set resulting in 'AuthError: Cannot send commands in PubSub mode' error.

### Summary
This is a fix to https://github.com/feathersjs-ecosystem/feathers-sync/issues/178

When a password is set on the redis server the following error is thrown by node-redis 4.x:
**AuthError: Cannot send commands in PubSub mode**

This happens because there is an internal state(_RedisCommandsQueue_pubSubState) in node-redis that gets set when the redis client .subscribe() method is called that will cause a subsequent call to the client .connect() method to fail with the aforementioned AuthError. I don't know if this is really an issue with node-redis or if it's user error but performing .subscribe() post .connect() in the ready Promise of feathers-sync gets around the issue.
