### PR TITLE
Try to guess context data that's required down stream

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -3,7 +3,13 @@ const feathers = require('@feathersjs/feathers');
 const { _ } = require('@feathersjs/commons');
 const SYNC = Symbol('feathers-sync/enabled');
 
-const defaultEvents = ['created', 'updated', 'removed', 'patched'];
+const eventMap = {
+  created: 'create',
+  updated: 'update',
+  patched: 'patch',
+  removed: 'remove'
+};
+const defaultEvents = Object.keys(eventMap);
 const getServiceOptions = service => {
   if (typeof feathers.getServiceOptions === 'function') {
     return feathers.getServiceOptions(service);
@@ -11,6 +17,17 @@ const getServiceOptions = service => {
 
   return {};
 };
+
+const constructContext = (app, service, event, data, context = {}) => {
+  const path = Object.entries(app.services).find(([_, value]) => value === service)[0];
+  return Object.assign({
+    path,
+    id: data._id || data.id,
+    method: eventMap[event],
+    params: {},
+    result: data,
+  }, context);
+}
 
 module.exports = app => {
   if (app[SYNC]) {
@@ -53,9 +70,10 @@ module.exports = app => {
         }
 
         const serializedContext = ctx && typeof ctx.toJSON === 'function' ? ctx.toJSON() : ctx;
+        const constructedContext = constructContext(app, service, event, data, serializedContext);
         const context = ctx && (ctx.app === app || ctx.service === service)
-          ? _.omit(serializedContext, 'app', 'service', 'self')
-          : serializedContext;
+          ? _.omit(constructedContext, 'app', 'service', 'self')
+          : constructedContext;
 
         debug(`Sending sync-out event '${path} ${event}'`);
 


### PR DESCRIPTION
### Summary

Currently if you need to manually submit an event, like you want to push an update after calling _patch, this lib requires you to build a context object manually or else it wont work properly:

```js
const newItem = await app.service(path)._patch(item._id, data);
app.service(path).emit('patched', newItem, { method: 'patch', id: item._id, result: newItem, path, params: {} });
```

most of the required info in context can already be gleaned from the execution context, so the code in this PR attempts a best guess context object. Whilst not perfect, it at least protects the developer from forgetting a fixed set of fields:

```js
app.service(path).emit('patched', newItem);
```