### PR TITLE
fix(amqp): remove event listener when channel is closed

### DIFF
--- a/lib/adapters/amqp.js
+++ b/lib/adapters/amqp.js
@@ -30,7 +30,7 @@ module.exports = (config) => {
             queue,
             (message) => {
               if (message !== null) {
-                debug(`Got ${key} event from APMQ channel`)
+                debug(`Got ${key} event from AMQP channel`)
                 app.emit('sync-in', message.content)
               }
             },
@@ -44,9 +44,9 @@ module.exports = (config) => {
                 queue,
                 Buffer.from(data)
               )
-              debug(`Publish success: |${publishResponse}| APMQ channel`)
+              debug(`Publish success: |${publishResponse}| AMQP channel`)
             } catch (error) {
-              debug(`Publish fail: |${error.message}| APMQ channel`)
+              debug(`Publish fail: |${error.message}| AMQP channel`)
             }
           }
 
@@ -60,7 +60,7 @@ module.exports = (config) => {
 
           return channel
         } catch (error) {
-          debug(`Publish fail: |${error.message}| APMQ channel`)
+          debug(`Publish fail: |${error.message}| AMQP channel`)
         }
       }
     })

--- a/lib/adapters/amqp.js
+++ b/lib/adapters/amqp.js
@@ -36,9 +36,9 @@ module.exports = (config) => {
             },
             { noAck: true }
           )
-          // Publish the received message to the queue
-          app.on('sync-out', (data) => {
-            try {
+
+          function publishToQueue(data) {
+           try {
               const publishResponse = channel.publish(
                 key,
                 queue,
@@ -48,7 +48,16 @@ module.exports = (config) => {
             } catch (error) {
               debug(`Publish fail: |${error.message}| APMQ channel`)
             }
+          }
+
+          // Publish the received message to the queue
+          app.on('sync-out', publishToQueue)
+
+          channel.on('close', () => {
+            debug('Channel closed')
+            app.off('sync-out', publishToQueue)
           })
+
           return channel
         } catch (error) {
           debug(`Publish fail: |${error.message}| APMQ channel`)


### PR DESCRIPTION
### Summary

Fixes #202.

I also took the liberty to fix the `APMQ` typos in the debug statements.

### Other Information

I tried to write a test for this, but couldn't get anything working that really verified that the issue was fixed. The test just times out... 

Here's the test code I attempted with:

Attempt one
```js
  it("unregisters event listeners when amqp connection is closed", async () => {
    const original = { test: "data" };

    let count = 0;

    const incrementCount = () => {
      count++;
    };

    app2.service("todo").on("created", incrementCount);
    onCreated(app2);

    app2.sync.connection.reconnect();

    // Wait for the connection to be back
    await new Promise((resolve) => {
      app2.sync.connection.once("connect", resolve);
    });

    await app1.service("todo").create(original);

    assert.strictEqual(count, 1);

    app2.service("todo").off("created", incrementCount);
  });
```

Attempt two
```js
  it("unregisters event listeners when amqp connection is closed", async () => {
    const original = { test: "data" };

    let count = 0;

    const incrementCount = () => {
      count++;
    };

    app2.service("todo").on("created", incrementCount);

    app2.sync.connection.close();

    await app2.sync.connection.connect();

    await app1.service("todo").create(original);

    assert.strictEqual(count, 1);

    app2.service("todo").off("created", incrementCount);
  });
```